### PR TITLE
Fixing Safari Bugs

### DIFF
--- a/docs/js/wave.js
+++ b/docs/js/wave.js
@@ -1,3 +1,5 @@
+var AudioContext = window.AudioContext          // Default
+    || window.webkitAudioContext;  // Safari and old versions of Chrome
 class Wave {
 
     constructor() {
@@ -556,9 +558,6 @@ class Wave {
         var audio = new Audio();
         audio.src = file;
 
-        var AudioContext = window.AudioContext          // Default
-            || window.webkitAudioContext;  // Safari and old versions of Chrome
-
         var audioCtx = new AudioContext();
         var analyser = audioCtx.createAnalyser();
 
@@ -641,9 +640,6 @@ class Wave {
         this.current_stream.options = options;
 
 
-        var AudioContext = window.AudioContext          // Default
-            || window.webkitAudioContext;  // Safari and old versions of Chrome
-
         var audioCtx, analyser, source;
         if (!this.sources[stream.toString()]) {
             audioCtx = new AudioContext();
@@ -711,9 +707,6 @@ class Wave {
             e = document.getElementById(e);
         }
 
-
-        var AudioContext = window.AudioContext          // Default
-            || window.webkitAudioContext;  // Safari and old versions of Chrome
 
 
         var audioCtx, analyser, source;

--- a/docs/js/wave.js
+++ b/docs/js/wave.js
@@ -1,9 +1,10 @@
 class Wave {
-    current_stream = {};
-    sources = {};
-    onFileLoad;
 
-    constructor() { }
+    constructor() {
+        this.current_stream = {};
+        this.sources = {};
+        this.onFileLoad;
+    }
 
     findSize(size) {
 
@@ -555,6 +556,9 @@ class Wave {
         var audio = new Audio();
         audio.src = file;
 
+        var AudioContext = window.AudioContext          // Default
+            || window.webkitAudioContext;  // Safari and old versions of Chrome
+
         var audioCtx = new AudioContext();
         var analyser = audioCtx.createAnalyser();
 
@@ -636,6 +640,10 @@ class Wave {
         this.current_stream.id = canvas_id;
         this.current_stream.options = options;
 
+
+        var AudioContext = window.AudioContext          // Default
+            || window.webkitAudioContext;  // Safari and old versions of Chrome
+
         var audioCtx, analyser, source;
         if (!this.sources[stream.toString()]) {
             audioCtx = new AudioContext();
@@ -702,6 +710,10 @@ class Wave {
         if (typeof e == "string") {
             e = document.getElementById(e);
         }
+
+
+        var AudioContext = window.AudioContext          // Default
+            || window.webkitAudioContext;  // Safari and old versions of Chrome
 
 
         var audioCtx, analyser, source;


### PR DESCRIPTION
- `Unexpected token` issue caused by Safari, as class variables should be declared in constructor
- Fixing Safari Bug for not finding audio context with fallback to `webkitAudioContext`