### PR TITLE
Opening the library to extension through the window globally stored objects accesses

### DIFF
--- a/dist/bundle.cjs.js
+++ b/dist/bundle.cjs.js
@@ -1,6 +1,25 @@
 'use strict';
 
 function fromElement(element_id, canvas_id, options) {
+    const globalAccessKey = [options.globalAccessKey || '$wave'];
+    const initGlobalObject = (elementId) => {
+        window[globalAccessKey] = window[globalAccessKey] || {};
+        window[globalAccessKey][elementId] = window[globalAccessKey][elementId] || {};
+    };
+
+    const getGlobal = options['getGlobal'] || function(elementId, accessKey) {
+        initGlobalObject(elementId);
+        return window[globalAccessKey][elementId][accessKey];
+    };
+
+    const setGlobal = options['setGlobal'] || function(elementId, accessKey, value) {
+        let returnValue = getGlobal(elementId);
+        if(!returnValue) {
+            window[globalAccessKey][elementId][accessKey] = window[globalAccessKey][elementId][accessKey] || value;
+            returnValue = window[globalAccessKey][elementId][accessKey];
+        }
+        return returnValue;
+    };
 
     const waveContext = this;
     let element = document.getElementById(element_id);
@@ -22,31 +41,21 @@ function fromElement(element_id, canvas_id, options) {
 
         const currentCount = this.activeElements[element_id].count;
 
-        //fix "AudioContext already connected" error
-        window.$wave = window.$wave || {};
-        window.$wave[element.id] = window.$wave[element.id] || {};
+        const audioCtx = setGlobal(element.id, 'audioCtx', new AudioContext());
+        const analyser = setGlobal(element.id, 'analyser', audioCtx.createAnalyser());
 
-        let audioCtx = window.$wave[element.id].audioCtx || new AudioContext();
-        window.$wave[element.id].audioCtx = audioCtx;
-
-        let analyser = window.$wave[element.id].analyzer || audioCtx.createAnalyser();
-        window.$wave[element.id].analyser = analyser;
-
-        //check if the element has a source already assigned and make sure they point to the same 
-        //reference because React will make a new element with a different reference
-        let source = null;
-        if (window.$wave[element.id].source)
-            if (window.$wave[element.id].source.mediaElement === element)
-                source = window.$wave[element.id].source;
-            else
+        let source = getGlobal(element.id, 'source');
+        if (source) {
+            if (source.mediaElement !== element) {
                 source = audioCtx.createMediaElementSource(element);
-        else
+            }
+        } else {
             source = audioCtx.createMediaElementSource(element);
-
-        window.$wave[element.id].source = source;
+        }
+        setGlobal(element.id, 'source', source);
 
         //beep test for ios
-        let oscillator = audioCtx.createOscillator();
+        const oscillator = audioCtx.createOscillator();
         oscillator.frequency.value = 1;
         oscillator.connect(audioCtx.destination);
         oscillator.start(0);
@@ -56,13 +65,13 @@ function fromElement(element_id, canvas_id, options) {
         source.connect(audioCtx.destination);
 
         analyser.fftsize = 32768;
-        let bufferLength = analyser.frequencyBinCount;
-        let data = new Uint8Array(bufferLength);
+        const bufferLength = analyser.frequencyBinCount;
+        const data = new Uint8Array(bufferLength);
         let frameCount = 1;
 
         function renderFrame() {
             //only run one wave visual per canvas
-            if (JSON.stringify(options) != this.activeCanvas[canvas_id]) {
+            if (JSON.stringify(options) !== this.activeCanvas[canvas_id]) {
                 return
             }
 

--- a/dist/bundle.iife.js
+++ b/dist/bundle.iife.js
@@ -2,6 +2,25 @@ var Wave = (function () {
     'use strict';
 
     function fromElement(element_id, canvas_id, options) {
+        const globalAccessKey = [options.globalAccessKey || '$wave'];
+        const initGlobalObject = (elementId) => {
+            window[globalAccessKey] = window[globalAccessKey] || {};
+            window[globalAccessKey][elementId] = window[globalAccessKey][elementId] || {};
+        };
+
+        const getGlobal = options['getGlobal'] || function(elementId, accessKey) {
+            initGlobalObject(elementId);
+            return window[globalAccessKey][elementId][accessKey];
+        };
+
+        const setGlobal = options['setGlobal'] || function(elementId, accessKey, value) {
+            let returnValue = getGlobal(elementId);
+            if(!returnValue) {
+                window[globalAccessKey][elementId][accessKey] = window[globalAccessKey][elementId][accessKey] || value;
+                returnValue = window[globalAccessKey][elementId][accessKey];
+            }
+            return returnValue;
+        };
 
         const waveContext = this;
         let element = document.getElementById(element_id);
@@ -23,31 +42,21 @@ var Wave = (function () {
 
             const currentCount = this.activeElements[element_id].count;
 
-            //fix "AudioContext already connected" error
-            window.$wave = window.$wave || {};
-            window.$wave[element.id] = window.$wave[element.id] || {};
+            const audioCtx = setGlobal(element.id, 'audioCtx', new AudioContext());
+            const analyser = setGlobal(element.id, 'analyser', audioCtx.createAnalyser());
 
-            let audioCtx = window.$wave[element.id].audioCtx || new AudioContext();
-            window.$wave[element.id].audioCtx = audioCtx;
-
-            let analyser = window.$wave[element.id].analyzer || audioCtx.createAnalyser();
-            window.$wave[element.id].analyser = analyser;
-
-            //check if the element has a source already assigned and make sure they point to the same 
-            //reference because React will make a new element with a different reference
-            let source = null;
-            if (window.$wave[element.id].source)
-                if (window.$wave[element.id].source.mediaElement === element)
-                    source = window.$wave[element.id].source;
-                else
+            let source = getGlobal(element.id, 'source');
+            if (source) {
+                if (source.mediaElement !== element) {
                     source = audioCtx.createMediaElementSource(element);
-            else
+                }
+            } else {
                 source = audioCtx.createMediaElementSource(element);
-
-            window.$wave[element.id].source = source;
+            }
+            setGlobal(element.id, 'source', source);
 
             //beep test for ios
-            let oscillator = audioCtx.createOscillator();
+            const oscillator = audioCtx.createOscillator();
             oscillator.frequency.value = 1;
             oscillator.connect(audioCtx.destination);
             oscillator.start(0);
@@ -57,13 +66,13 @@ var Wave = (function () {
             source.connect(audioCtx.destination);
 
             analyser.fftsize = 32768;
-            let bufferLength = analyser.frequencyBinCount;
-            let data = new Uint8Array(bufferLength);
+            const bufferLength = analyser.frequencyBinCount;
+            const data = new Uint8Array(bufferLength);
             let frameCount = 1;
 
             function renderFrame() {
                 //only run one wave visual per canvas
-                if (JSON.stringify(options) != this.activeCanvas[canvas_id]) {
+                if (JSON.stringify(options) !== this.activeCanvas[canvas_id]) {
                     return
                 }
 

--- a/src/fromElement.js
+++ b/src/fromElement.js
@@ -1,4 +1,23 @@
 export default function fromElement(element_id, canvas_id, options) {
+    const globalAccessKey = [options.globalAccessKey || '$wave'];
+    const initGlobalObject = (elementId) => {
+        window[globalAccessKey] = window[globalAccessKey] || {};
+        window[globalAccessKey][elementId] = window[globalAccessKey][elementId] || {};
+    };
+
+    const getGlobal = options['getGlobal'] || function(elementId, accessKey) {
+        initGlobalObject(elementId);
+        return window[globalAccessKey][elementId][accessKey];
+    };
+
+    const setGlobal = options['setGlobal'] || function(elementId, accessKey, value) {
+        let returnValue = getGlobal(elementId);
+        if(!returnValue) {
+            window[globalAccessKey][elementId][accessKey] = window[globalAccessKey][elementId][accessKey] || value;
+            returnValue = window[globalAccessKey][elementId][accessKey];
+        }
+        return returnValue;
+    };
 
     const waveContext = this;
     let element = document.getElementById(element_id);
@@ -20,31 +39,21 @@ export default function fromElement(element_id, canvas_id, options) {
 
         const currentCount = this.activeElements[element_id].count
 
-        //fix "AudioContext already connected" error
-        window.$wave = window.$wave || {}
-        window.$wave[element.id] = window.$wave[element.id] || {}
+        const audioCtx = setGlobal(element.id, 'audioCtx', new AudioContext());
+        const analyser = setGlobal(element.id, 'analyser', audioCtx.createAnalyser());
 
-        let audioCtx = window.$wave[element.id].audioCtx || new AudioContext();
-        window.$wave[element.id].audioCtx = audioCtx
-
-        let analyser = window.$wave[element.id].analyzer || audioCtx.createAnalyser();
-        window.$wave[element.id].analyser = analyser
-
-        //check if the element has a source already assigned and make sure they point to the same 
-        //reference because React will make a new element with a different reference
-        let source = null;
-        if (window.$wave[element.id].source)
-            if (window.$wave[element.id].source.mediaElement === element)
-                source = window.$wave[element.id].source
-            else
+        let source = getGlobal(element.id, 'source');
+        if (source) {
+            if (source.mediaElement !== element) {
                 source = audioCtx.createMediaElementSource(element);
-        else
+            }
+        } else {
             source = audioCtx.createMediaElementSource(element);
-
-        window.$wave[element.id].source = source
+        }
+        setGlobal(element.id, 'source', source);
 
         //beep test for ios
-        let oscillator = audioCtx.createOscillator();
+        const oscillator = audioCtx.createOscillator();
         oscillator.frequency.value = 1;
         oscillator.connect(audioCtx.destination);
         oscillator.start(0);
@@ -54,13 +63,13 @@ export default function fromElement(element_id, canvas_id, options) {
         source.connect(audioCtx.destination)
 
         analyser.fftsize = 32768;
-        let bufferLength = analyser.frequencyBinCount;
-        let data = new Uint8Array(bufferLength);
+        const bufferLength = analyser.frequencyBinCount;
+        const data = new Uint8Array(bufferLength);
         let frameCount = 1
 
         function renderFrame() {
             //only run one wave visual per canvas
-            if (JSON.stringify(options) != this.activeCanvas[canvas_id]) {
+            if (JSON.stringify(options) !== this.activeCanvas[canvas_id]) {
                 return
             }
 


### PR DESCRIPTION
For `fromElement` method, the way `Wave.js` is storing data in the window makes prevents it from working with other libraries that aim to share the same context.

This not-breaking change is adding 2 ways to handle that problematic : 

-  `options.globalAccessKey: <any string>`: Simply replaces `$wave` in the old `window.$wave` by any other storage access string
- Or these 2 following methods that will offer a full custom implementation to the user :  
```
getGlobal: (elementId, accessKey) => { // any implementation  }
setGlobal: (elementId, accessKey, value) => { // any implementation  }
```
