### PR TITLE
[chore] Creating skipUserEventsWatcher option

### DIFF
--- a/dist/bundle.cjs.js
+++ b/dist/bundle.cjs.js
@@ -106,7 +106,7 @@ function fromElement(element_id, canvas_id, options) {
         run.call(waveContext);
     };
 
-    if (this.activated) {
+    if (this.activated || options['skipUserEventsWatcher']) {
         run.call(waveContext);
     } else {
         //wait for a valid user gesture 

--- a/dist/bundle.iife.js
+++ b/dist/bundle.iife.js
@@ -107,7 +107,7 @@ var Wave = (function () {
             run.call(waveContext);
         };
 
-        if (this.activated) {
+        if (this.activated || options['skipUserEventsWatcher']) {
             run.call(waveContext);
         } else {
             //wait for a valid user gesture 

--- a/src/fromElement.js
+++ b/src/fromElement.js
@@ -104,7 +104,7 @@ export default function fromElement(element_id, canvas_id, options) {
         run.call(waveContext)
     }
 
-    if (this.activated) {
+    if (this.activated || options['skipUserEventsWatcher']) {
         run.call(waveContext)
     } else {
         //wait for a valid user gesture 


### PR DESCRIPTION
Sometimes we want to activate the visualizer as soon as it's displayed, therefore, we don't want to wait for a user mouse event to trigger the activation. This PR takes into account a new option `skipUserEventsWatcher`, which will allow the user to activate the visualizer immediately.