### PR TITLE
chore: making the connection to audio device optional

### DIFF
--- a/dist/bundle.cjs.js
+++ b/dist/bundle.cjs.js
@@ -1,7 +1,12 @@
 'use strict';
 
-function fromElement(element_id, canvas_id, options) {
-    const globalAccessKey = [options.globalAccessKey || '$wave'];
+function fromElement(element_id, canvas_id, userOptions = {}) {
+    const options = {
+        autoConnect: true,
+        globalAccessKey: '$wave',
+        ...userOptions,
+    };
+    const { globalAccessKey } = options;
     const initGlobalObject = (elementId) => {
         window[globalAccessKey] = window[globalAccessKey] || {};
         window[globalAccessKey][elementId] = window[globalAccessKey][elementId] || {};
@@ -13,7 +18,7 @@ function fromElement(element_id, canvas_id, options) {
     };
 
     const setGlobal = options['setGlobal'] || function(elementId, accessKey, value) {
-        let returnValue = getGlobal(elementId);
+        let returnValue = getGlobal(elementId, accessKey);
         if(!returnValue) {
             window[globalAccessKey][elementId][accessKey] = window[globalAccessKey][elementId][accessKey] || value;
             returnValue = window[globalAccessKey][elementId][accessKey];
@@ -62,7 +67,9 @@ function fromElement(element_id, canvas_id, options) {
         oscillator.stop(0);
 
         source.connect(analyser);
-        source.connect(audioCtx.destination);
+        if (options.autoConnect) {
+            source.connect(audioCtx.destination);
+        }
 
         analyser.fftsize = 32768;
         const bufferLength = analyser.frequencyBinCount;
@@ -82,7 +89,7 @@ function fromElement(element_id, canvas_id, options) {
             requestAnimationFrame(renderFrame);
             frameCount++;
 
-            //check if this element is the last to be called 
+            //check if this element is the last to be called
             if (!(currentCount < this.activeElements[element_id].count)) {
                 analyser.getByteFrequencyData(data);
                 this.activeElements[element_id].data = data;
@@ -109,7 +116,7 @@ function fromElement(element_id, canvas_id, options) {
     if (this.activated || options['skipUserEventsWatcher']) {
         run.call(waveContext);
     } else {
-        //wait for a valid user gesture 
+        //wait for a valid user gesture
         document.body.addEventListener("touchstart", create, { once: true });
         document.body.addEventListener("touchmove", create, { once: true });
         document.body.addEventListener("touchend", create, { once: true });

--- a/dist/bundle.iife.js
+++ b/dist/bundle.iife.js
@@ -1,8 +1,13 @@
 var Wave = (function () {
     'use strict';
 
-    function fromElement(element_id, canvas_id, options) {
-        const globalAccessKey = [options.globalAccessKey || '$wave'];
+    function fromElement(element_id, canvas_id, userOptions = {}) {
+        const options = {
+            autoConnect: true,
+            globalAccessKey: '$wave',
+            ...userOptions,
+        };
+        const { globalAccessKey } = options;
         const initGlobalObject = (elementId) => {
             window[globalAccessKey] = window[globalAccessKey] || {};
             window[globalAccessKey][elementId] = window[globalAccessKey][elementId] || {};
@@ -14,7 +19,7 @@ var Wave = (function () {
         };
 
         const setGlobal = options['setGlobal'] || function(elementId, accessKey, value) {
-            let returnValue = getGlobal(elementId);
+            let returnValue = getGlobal(elementId, accessKey);
             if(!returnValue) {
                 window[globalAccessKey][elementId][accessKey] = window[globalAccessKey][elementId][accessKey] || value;
                 returnValue = window[globalAccessKey][elementId][accessKey];
@@ -63,7 +68,9 @@ var Wave = (function () {
             oscillator.stop(0);
 
             source.connect(analyser);
-            source.connect(audioCtx.destination);
+            if (options.autoConnect) {
+                source.connect(audioCtx.destination);
+            }
 
             analyser.fftsize = 32768;
             const bufferLength = analyser.frequencyBinCount;
@@ -83,7 +90,7 @@ var Wave = (function () {
                 requestAnimationFrame(renderFrame);
                 frameCount++;
 
-                //check if this element is the last to be called 
+                //check if this element is the last to be called
                 if (!(currentCount < this.activeElements[element_id].count)) {
                     analyser.getByteFrequencyData(data);
                     this.activeElements[element_id].data = data;
@@ -110,7 +117,7 @@ var Wave = (function () {
         if (this.activated || options['skipUserEventsWatcher']) {
             run.call(waveContext);
         } else {
-            //wait for a valid user gesture 
+            //wait for a valid user gesture
             document.body.addEventListener("touchstart", create, { once: true });
             document.body.addEventListener("touchmove", create, { once: true });
             document.body.addEventListener("touchend", create, { once: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@foobar404/wave",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foobar404/wave",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Audio visualizer library for javascript (20+ designs).",
   "main": "dist/bundle.cjs.js",
   "directories": {


### PR DESCRIPTION
When the destination of the AudioContext has already been connected to the audio context, we must offer an option to the user so that he can avoid a new useless connection that might result in a micro-cut of the sound. 

Note: The default behaviour remains the same, this PR just adds an optional parameter to handle this particular case when audio context destination is already connected from somewhere else.